### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/vg-projects-org/b1399e24-5e8d-4cac-9467-98bb555a4fa8/d8c6ef26-931a-412f-bae4-0d265b7f1180/_apis/work/boardbadge/e973676a-b4e7-4235-a111-de824bacb690)](https://dev.azure.com/vg-projects-org/b1399e24-5e8d-4cac-9467-98bb555a4fa8/_boards/board/t/d8c6ef26-931a-412f-bae4-0d265b7f1180/Microsoft.RequirementCategory)
 My DSA Practice Problems


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/vg-projects-org/b1399e24-5e8d-4cac-9467-98bb555a4fa8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.